### PR TITLE
Get the default database name easily

### DIFF
--- a/src/tangojs-connector-mtango/MTangoConnector.js
+++ b/src/tangojs-connector-mtango/MTangoConnector.js
@@ -93,6 +93,17 @@ export class MTangoConnector extends tangojs.Connector {
   }
 
   /**
+   * @return {Promise<string,Error>}
+   */
+  get_database () {
+
+    // http://localhost:8080/mtango/rest/rc3/hosts/localhost/10000/
+
+    return this._fetch('get', '')
+      .then(info => info.name)
+  }
+
+  /**
    * @param {string} devname
    * @return {Promise<string,Error>}
    */


### PR DESCRIPTION
Get the default database name easily

`connector.get_database().then(name => {
        console.log(`Here we go: ${name}`)
        return new DeviceProxy(name)    
      })
`

Moreover we can use it in Tangojs core to create a Database proxy without to give any explicit device name.